### PR TITLE
Add `writeClient` for Sanity write operations; patch `View` component…

### DIFF
--- a/components/View.tsx
+++ b/components/View.tsx
@@ -1,11 +1,20 @@
+import {after} from "next/server";
 import Ping from "@/components/Ping";
 import {client} from "@/sanity/lib/client";
 import {STARTUP_VIEWS_QUERY, type StartupViews} from "@/sanity/lib/queries";
+import {writeClient} from "@/sanity/lib/write-client";
 
 async function View(props: {id: string}) {
   const data = await client
-    .withConfig({useCdn: true})
+    .withConfig({useCdn: false})
     .fetch<StartupViews>(STARTUP_VIEWS_QUERY, {id: props.id});
+
+  after(async () => {
+    await writeClient
+      .patch(props.id)
+      .set({views: (data.views || 0) + 1})
+      .commit();
+  });
 
   return (
     <div className="view-container">

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tailwindcss/typography": "^0.5.16",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "easymde": "^2.20.0",
         "lucide-react": "^0.544.0",
         "markdown-it": "^14.1.0",
         "next": "15.6.0-canary.7",
@@ -6835,6 +6836,12 @@
         "@types/mdurl": "^2"
       }
     },
+    "node_modules/@types/marked": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
+      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
@@ -8786,6 +8793,15 @@
         "@codemirror/view": "^6.0.0"
       }
     },
+    "node_modules/codemirror-spell-checker": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz",
+      "integrity": "sha512-2Tl6n0v+GJRsC9K3MLCdLaMOmvWL0uukajNJseorZJsslaxZyZMgENocPU8R0DyoTAiKsyqiemSOZo7kjGV0LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "typo-js": "*"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -9671,6 +9687,25 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/easymde": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.20.0.tgz",
+      "integrity": "sha512-V1Z5f92TfR42Na852OWnIZMbM7zotWQYTddNaLYZFVKj7APBbyZ3FYJ27gBw2grMW3R6Qdv9J8n5Ij7XRSIgXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/codemirror": "^5.60.10",
+        "@types/marked": "^4.0.7",
+        "codemirror": "^5.65.15",
+        "codemirror-spell-checker": "1.1.2",
+        "marked": "^4.1.0"
+      }
+    },
+    "node_modules/easymde/node_modules/codemirror": {
+      "version": "5.65.20",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.20.tgz",
+      "integrity": "sha512-i5dLDDxwkFCbhjvL2pNjShsojoL3XHyDwsGv1jqETUoW+lzpBKKqNTUWgQwVAOa0tUm4BwekT455ujafi8payA==",
       "license": "MIT"
     },
     "node_modules/ejs": {
@@ -13394,6 +13429,18 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/math-intrinsics": {
@@ -17977,6 +18024,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/typo-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/typo-js/-/typo-js-1.3.1.tgz",
+      "integrity": "sha512-elJkpCL6Z77Ghw0Lv0lGnhBAjSTOQ5FhiVOCfOuxhaoTT2xtLVbqikYItK5HHchzPbHEUFAcjOH669T2ZzeCbg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/uc.micro": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tailwindcss/typography": "^0.5.16",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "easymde": "^2.20.0",
     "lucide-react": "^0.544.0",
     "markdown-it": "^14.1.0",
     "next": "15.6.0-canary.7",

--- a/sanity/env.ts
+++ b/sanity/env.ts
@@ -11,6 +11,11 @@ export const projectId = assertValue(
   "Missing environment variable: NEXT_PUBLIC_SANITY_PROJECT_ID",
 );
 
+export const token = assertValue(
+  process.env.SANITY_WRITE_TOKEN,
+  "Missing environment variable: SANITY_WRITE_TOKEN",
+);
+
 function assertValue<T>(v: T | undefined, errorMessage: string): T {
   if (v === undefined) {
     throw new Error(errorMessage);

--- a/sanity/lib/client.ts
+++ b/sanity/lib/client.ts
@@ -5,5 +5,5 @@ export const client = createClient({
   projectId,
   dataset,
   apiVersion,
-  useCdn: false, // Set to false if statically generating pages, using ISR or tag-based revalidation
+  useCdn: true, // Set to false if statically generating pages, using ISR or tag-based revalidation
 });

--- a/sanity/lib/write-client.ts
+++ b/sanity/lib/write-client.ts
@@ -1,0 +1,15 @@
+import "server-only";
+import {createClient} from "next-sanity";
+import {apiVersion, dataset, projectId, token} from "../env";
+
+export const writeClient = createClient({
+  projectId,
+  dataset,
+  apiVersion,
+  token,
+  useCdn: false, // Set to false if statically generating pages, using ISR or tag-based revalidation
+});
+
+if (!writeClient.config().token) {
+  throw new Error("Missing write token");
+}


### PR DESCRIPTION
… to update views:

- Introduced `writeClient` to handle Sanity write operations with token validation.
- Updated `View` component to increment and save view count asynchronously using `writeClient`.
- Adjusted `useCdn` configuration in `client` setup for read and write purposes.
- Added `easymde` and related dependencies to `package.json`.