### PR TITLE
Add `createPitch` action and implement dynamic `slug` generation

### DIFF
--- a/components/StartupCard.tsx
+++ b/components/StartupCard.tsx
@@ -28,7 +28,7 @@ function StartupCard(props: {post: StartupPost}) {
         </div>
         <Link href={`/user/${post?.author?._id}`}>
           <Image
-            src="https://placehold.co/48x48"
+            src={post?.author?.image || "https://placehold.co/48x48"}
             alt="placeholder"
             width={48}
             height={48}

--- a/components/StartupForm.tsx
+++ b/components/StartupForm.tsx
@@ -5,12 +5,17 @@ import {useRouter} from "next/navigation";
 import {Send} from "lucide-react";
 import {z} from "zod";
 import {schema} from "@/lib/validation";
+import {createPitch} from "@/lib/actions";
 import {useToast} from "@/hooks/use-toast";
 import {Button} from "@/components/ui/button";
 import InputText from "@/components/InputText";
 import Textarea from "@/components/Textarea";
 import InputMarkdown from "@/components/InputMarkdown";
-import {getInitialState, getInitialErrors} from "@/components/map-values";
+import {
+  getInitialState,
+  getInitialErrors,
+  getInitialValues,
+} from "@/components/map-values";
 
 function StartupForm() {
   const [pitch, setPitch] = React.useState("");
@@ -25,26 +30,26 @@ function StartupForm() {
       description: formData.get("description") as string,
       category: formData.get("category") as string,
       link: formData.get("link") as string,
-      pitch,
+      pitch: formData.get("pitch") as string,
     };
 
     try {
       await schema.parseAsync(values);
-      // const result = await createIdea(values);
-      // console.log(result)
 
-      // if (result.status === "SUCCESS") {
-      //   toast({
-      //     title: "Success",
-      //     description: "Your startup pitch has been created successfully",
-      //   });
-      //
-      //   router.push(`/startup/${result.id}`);
-      // }
+      const result = await createPitch(_, formData);
+
+      if (result.status === "SUCCESS") {
+        toast({
+          title: "Success",
+          description: "Your startup pitch has been created successfully",
+        });
+
+        router.push(`/startup/${result._id}`);
+      }
 
       return {
         status: "success",
-        values,
+        values: getInitialValues(),
         errors: getInitialErrors(),
       };
     } catch (error) {

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -1,0 +1,68 @@
+"use server";
+
+import slugify from "slugify";
+import {auth} from "@/auth";
+import {isString, parseServerActionResponse} from "@/lib/utils";
+import {writeClient} from "@/sanity/lib/write-client";
+import {StartupPayload} from "@/sanity/lib/queries";
+
+export async function createPitch(_: unknown, form: FormData) {
+  const session = await auth();
+
+  if (!session) {
+    return parseServerActionResponse({
+      error: "Not signed in",
+      status: "FAILURE",
+    });
+  }
+
+  const title = form.get("title");
+  const description = form.get("description");
+  const category = form.get("category");
+  const link = form.get("link");
+  const pitch = form.get("pitch");
+
+  if (
+    isString(title) &&
+    isString(description) &&
+    isString(category) &&
+    isString(link) &&
+    isString(pitch)
+  ) {
+    try {
+      const payload: StartupPayload = {
+        _type: "startup",
+        title,
+        description,
+        category,
+        image: link,
+        slug: {
+          _type: "slug",
+          current: slugify(title, {lower: true, strict: true}),
+        },
+        author: {
+          _type: "reference",
+          _ref: session.id,
+        },
+        pitch,
+      };
+      const result = await writeClient.create(payload);
+
+      return parseServerActionResponse({
+        ...result,
+        error: "",
+        status: "SUCCESS",
+      });
+    } catch (error) {
+      return parseServerActionResponse({
+        status: "FAILURE",
+        error: JSON.stringify(error),
+      });
+    }
+  }
+
+  return parseServerActionResponse({
+    status: "FAILURE",
+    error: "Invalid form submission",
+  });
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,3 +12,11 @@ export function formatDate(date: string) {
     year: "numeric",
   });
 }
+
+export function parseServerActionResponse<T>(response: T) {
+  return JSON.parse(JSON.stringify(response));
+}
+
+export function isString(test: unknown) {
+  return typeof test === "string";
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "placecats.com",
       },
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
     ],
   },
   experimental: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "sanity": "^4.8.1",
         "sanity-plugin-markdown": "^6.0.0",
         "server-only": "^0.0.1",
+        "slugify": "^1.6.6",
         "styled-components": "^6.1.19",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7"
@@ -18836,6 +18837,15 @@
         "react-dom": ">=18.2.0",
         "slate": ">=0.114.0",
         "slate-dom": ">=0.116.0"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "sanity": "^4.8.1",
     "sanity-plugin-markdown": "^6.0.0",
     "server-only": "^0.0.1",
+    "slugify": "^1.6.6",
     "styled-components": "^6.1.19",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7"

--- a/sanity/lib/queries.ts
+++ b/sanity/lib/queries.ts
@@ -18,6 +18,18 @@ export type AuthorQueryData = Pick<
   "_id" | "id" | "name" | "username" | "email" | "image" | "bio"
 >;
 
+export type StartupPayload = Pick<
+  Startup,
+  | "_type"
+  | "title"
+  | "description"
+  | "category"
+  | "image"
+  | "slug"
+  | "author"
+  | "pitch"
+>;
+
 export const STARTUP_QUERY =
   defineQuery(`*[_type == "startup" && defined(slug.current) && !defined($search) || title match $search || category match $search || author->name match $search] | order(_createdAt desc) {
   _id,


### PR DESCRIPTION
- Introduced `createPitch` server action for handling startup pitch submissions.
- Added `slugify` dependency for generating slugs dynamically from titles.
- Updated `StartupForm` to utilize `createPitch` for form submission and validation.
- Enhanced `StartupCard` to display user avatars dynamically.
- Allowed additional image domains in `next.config.ts` for GitHub avatars.
- Included `getInitialValues` utility and updated `map-values` import in `StartupForm`.
- Extended Sanity queries with a `StartupPayload` type for startup data consistency.