### PR TITLE
Add `Playlist` schema, dynamic query, and UI integration (#6)

### DIFF
--- a/app/(root)/startup/[id]/page.tsx
+++ b/app/(root)/startup/[id]/page.tsx
@@ -5,9 +5,15 @@ import Image from "next/image";
 import markdownit from "markdown-it";
 import {formatDate} from "@/lib/utils";
 import {client} from "@/sanity/lib/client";
-import {STARTUP_BY_ID_QUERY, type StartupData} from "@/sanity/lib/queries";
+import {
+  PLAYLIST_BY_SLUG_QUERY,
+  STARTUP_BY_ID_QUERY,
+  type StartupData,
+  type PlaylistQueryData,
+} from "@/sanity/lib/queries";
 import {Skeleton} from "@/components/ui/skeleton";
 import View from "@/components/View";
+import StartupCard from "@/components/StartupCard";
 
 export const experimental_ppr = true;
 
@@ -15,9 +21,10 @@ const md = markdownit();
 
 async function Page(props: {params: Promise<{id: string}>}) {
   const params = await props.params;
-  const data = await client.fetch<StartupData>(STARTUP_BY_ID_QUERY, {
-    id: params.id,
-  });
+  const [data, {select}] = await Promise.all([
+    client.fetch<StartupData>(STARTUP_BY_ID_QUERY, {id: params.id}),
+    client.fetch<PlaylistQueryData>(PLAYLIST_BY_SLUG_QUERY, {slug: "temp"}),
+  ]);
 
   if (!data) {
     return notFound();
@@ -70,6 +77,20 @@ async function Page(props: {params: Promise<{id: string}>}) {
           {!parsedContent && <p className="no-result">No details provided</p>}
         </div>
         <hr className="divider" />
+        <div className="mx-auto max-w-4xl">
+          <p className="text-30-semibold">Editor Picks</p>
+          <ul className="card_grid-sm mt-7">
+            {select.length === 0 && (
+              <p className="no-result">No results found</p>
+            )}
+            {select.map((post, index) => (
+              <StartupCard
+                key={index}
+                post={post}
+              />
+            ))}
+          </ul>
+        </div>
         <React.Suspense fallback={<Skeleton className="view-skeleton" />}>
           <View id={data._id} />
         </React.Suspense>

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -28,7 +28,8 @@ const toastVariants = cva(
   {
     variants: {
       variant: {
-        default: "border bg-background text-foreground",
+        default:
+          "border bg-white text-slate-950 dark:bg-slate-950 dark:text-slate-50",
         destructive:
           "destructive group border-destructive bg-destructive text-destructive-foreground",
       },

--- a/sanity/extract.json
+++ b/sanity/extract.json
@@ -1,5 +1,101 @@
 [
   {
+    "name": "playlist",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "playlist"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        },
+        "optional": true
+      },
+      "select": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "_ref": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "reference"
+                }
+              },
+              "_weak": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "boolean"
+                },
+                "optional": true
+              }
+            },
+            "dereferencesTo": "startup",
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
     "name": "startup",
     "type": "document",
     "attributes": {

--- a/sanity/lib/queries.ts
+++ b/sanity/lib/queries.ts
@@ -1,5 +1,5 @@
 import {defineQuery} from "next-sanity";
-import type {Author, Startup} from "@/sanity/types";
+import type {Author, Startup, Playlist} from "@/sanity/types";
 
 export type StartupsQueryData = StartupPost[];
 
@@ -29,6 +29,10 @@ export type StartupPayload = Pick<
   | "author"
   | "pitch"
 >;
+
+export type PlaylistQueryData = Pick<Playlist, "_id" | "title" | "slug"> & {
+  select: Array<StartupPost>;
+};
 
 export const STARTUPS_QUERY =
   defineQuery(`*[_type == "startup" && defined(slug.current) && !defined($search) || title match $search || category match $search || author->name match $search] | order(_createdAt desc) {
@@ -112,4 +116,27 @@ export const STARTUPS_BY_AUTHOR_QUERY =
   description,
   category,
   image
+}`);
+
+export const PLAYLIST_BY_SLUG_QUERY =
+  defineQuery(`*[_type == "playlist" && slug.current == $slug][0] {
+  _id,
+  title,
+  slug,
+  select[]-> {
+    _id,
+    _createdAt,
+    title,
+    slug,
+    author -> {
+      _id,
+      name,
+      image,
+      bio
+    },
+    views,
+    description,
+    category,
+    image
+  }
 }`);

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -1,7 +1,8 @@
 import {type SchemaTypeDefinition} from "sanity";
 import {author} from "./author";
 import {startup} from "./startup";
+import {playlist} from "./playlist";
 
 export const schema: {types: SchemaTypeDefinition[]} = {
-  types: [author, startup],
+  types: [author, startup, playlist],
 };

--- a/sanity/schemaTypes/playlist.ts
+++ b/sanity/schemaTypes/playlist.ts
@@ -1,0 +1,30 @@
+import {defineType, defineField} from "sanity";
+
+export const playlist = defineType({
+  name: "playlist",
+  title: "Playlists",
+  type: "document",
+  fields: [
+    defineField({
+      name: "title",
+      type: "string",
+    }),
+    defineField({
+      name: "slug",
+      type: "slug",
+      options: {
+        source: "title",
+      },
+    }),
+    defineField({
+      name: "select",
+      type: "array",
+      of: [
+        {
+          type: "reference",
+          to: [{type: "startup"}],
+        },
+      ],
+    }),
+  ],
+});

--- a/sanity/types.ts
+++ b/sanity/types.ts
@@ -13,6 +13,23 @@
  */
 
 // Source: schema.json
+export type Playlist = {
+  _id: string;
+  _type: "playlist";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  title?: string;
+  slug?: Slug;
+  select?: Array<{
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    _key: string;
+    [internalGroqTypeReferenceTo]?: "startup";
+  }>;
+};
+
 export type Startup = {
   _id: string;
   _type: "startup";
@@ -169,6 +186,7 @@ export type SanityAssetSourceData = {
 };
 
 export type AllSanitySchemaTypes =
+  | Playlist
   | Startup
   | Author
   | Markdown


### PR DESCRIPTION
- Defined `Playlist` schema in Sanity with `title`, `slug`, and `select` fields.
- Added `PLAYLIST_BY_SLUG_QUERY` for fetching playlist data.
- Updated `Startup` page to display a curated playlist section ("Editor Picks").
- Implemented `Avatar` component using `@radix-ui/react-avatar`.
- Enhanced default toast styles for dark and light themes.